### PR TITLE
API implementation overhaul

### DIFF
--- a/plugin/API.pm
+++ b/plugin/API.pm
@@ -1,0 +1,163 @@
+package Plugins::YouTube::API;
+
+use strict;
+
+use Digest::MD5 qw(md5_hex);
+use File::Spec::Functions qw(catdir);
+use JSON::XS::VersionOneAndTwo;
+use List::Util qw(min max);
+use URI::Escape qw(uri_escape uri_escape_utf8);
+
+use constant API_URL => 'https://www.googleapis.com/youtube/v3/';
+use constant DEFAULT_CACHE_TTL => 3600;
+
+use Slim::Utils::Cache;
+use Slim::Utils::Log;
+use Slim::Utils::Prefs;
+
+my $prefs = preferences('plugin.youtube');
+my $log   = logger('plugin.youtube.api');
+my $cache = Slim::Utils::Cache->new();
+	
+sub search {
+	my ( $class, $cb, $args ) = @_;
+	
+	warn Data::Dump::dump($args);
+	$args ||= {};
+	$args->{maxResults} = 50;
+	$args->{part}       = 'snippet';
+	$args->{type}     ||= 'video';
+	$args->{relevanceLanguage} = Slim::Utils::Strings::getLanguage();
+	
+	_pagedCall('search', $args, $cb);
+}
+
+sub searchVideos {
+	my ( $class, $cb, $args ) = @_;
+	
+	$args ||= {};
+	$args->{type} = 'video';
+	$class->search($cb, $args);
+}	
+
+sub searchChannels {
+	my ( $class, $cb, $args ) = @_;
+	
+	$args ||= {};
+	$args->{type} = 'channel';
+	$class->search($cb, $args);
+}
+
+sub searchPlaylists {
+	my ( $class, $cb, $args ) = @_;
+	
+	$args ||= {};
+	$args->{type} = 'playlist';
+	$class->search($cb, $args);
+}
+
+sub getVideoCategories {
+	my ( $class, $cb ) = @_;
+	
+	_pagedCall('videoCategories', {
+		hl => Slim::Utils::Strings::getLanguage()
+	}, $cb);
+}
+
+sub _pagedCall {
+	my ( $method, $args, $cb ) = @_;
+	
+	my $maxItems = delete $args->{maxItems} || $prefs->get('max_items');
+
+	my $items = [];
+	my ($offset, $resultsAvailable);
+	
+	my $pagingCb;
+	
+	$pagingCb = sub {
+		my $results = shift;
+
+		push @$items, @{$results->{items}};
+		
+		main::INFOLOG && $log->info("We want $maxItems items, have " . scalar @$items . " so far");
+		
+		if (@$items < $maxItems && $results->{nextPageToken}) {
+			$args->{pageToken} = $results->{nextPageToken};
+			main::INFOLOG && $log->info("Get next page using token " . $args->{pageToken});
+
+#			require Slim::Utils::Timers;
+#			Slim::Utils::Timers::setTimer( undef, time() + 0.1, sub {
+				_call($method, $args, $pagingCb);
+#			} );
+		}
+		else {
+			main::INFOLOG && $log->info("Got all we wanted. Return " . scalar @$items . " items.");
+			$results->{items} = $items;
+			$cb->($results);
+		}
+	};
+
+	_call($method, $args, $pagingCb);
+}
+
+
+sub _call {
+	my ( $method, $args, $cb ) = @_;
+	
+	my $url = '?' . (delete $args->{_noKey} ? '' : 'key=' . $prefs->get('APIkey') . '&');
+	
+	$args->{regionCode} ||= $prefs->get('country') unless delete $args->{_noRegion};
+	$args->{part}       ||= 'snippet' unless delete $args->{_noPart};
+
+	for my $k ( sort keys %{$args} ) {
+		next if $k =~ /^_/;
+		$url .= $k . '=' . URI::Escape::uri_escape_utf8( Encode::decode( 'utf8', $args->{$k} ) ) . '&';
+	}
+	
+	my $cacheKey = $args->{_noCache} ? '' : md5_hex($url);
+	
+	if ( $cacheKey && (my $cached = $cache->get($cacheKey)) ) {
+		main::INFOLOG && $log->info("Returning cached data for: $url");
+		$cb->($cached);
+		return;
+	}
+	
+	$url =~ s/&$//;
+	$url = API_URL . $method . $url;
+	
+	main::INFOLOG && $log->info('Calling API: ' . $url);
+
+	Slim::Networking::SimpleAsyncHTTP->new(
+		sub {
+			my $response = shift;
+			
+			my $result = eval { from_json($response->content) };
+			
+			if ($@) {
+				$log->error(Data::Dump::dump($response)) unless main::DEBUGLOG && $log->is_debug;
+				$log->error($@);
+			}
+
+			main::DEBUGLOG && $log->is_debug && warn Data::Dump::dump($result);
+
+			$result ||= {};
+			
+			$cache->set($cacheKey, $result, DEFAULT_CACHE_TTL);
+
+			$cb->($result);
+		},
+
+		sub {
+			warn Data::Dump::dump(@_);
+			$log->error($_[1]);
+			$cb->([ { name => $_[1], type => 'text' } ]);
+		},
+		
+		{
+			timeout => 15,
+		}
+
+	)->get($url);
+}
+
+1;

--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -315,15 +315,15 @@ sub playlistHandler {
 sub trackInfoMenu {
 	my ($client, $url, $track, $remoteMeta) = @_;
 
-	# XXX - should we search for track title, too?
-	my $artist = ($remoteMeta && $remoteMeta->{artist}) || ($track && $track->artistName);
+	my $artist = ($remoteMeta && $remoteMeta->{artist}) || ($track && $track->artistName) || '';
+	my $title  = ($remoteMeta && $remoteMeta->{title}) || ($track && $track->title) || '';
 
-	if ($artist) {
+	if ($artist || $title) {
 		return {
 			type      => 'outline',
 			name      => cstring($client, 'PLUGIN_YOUTUBE_ON_YOUTUBE'),
 			url       => \&videoSearchHandler,
-			passthrough => [ { q => $artist } ], 
+			passthrough => [ { q => "$artist $title" } ], 
 		};
 	}
 }

--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -411,7 +411,7 @@ sub decode_u16 { unpack('n', $_[0]) }
 sub decode_u24 { unpack('N', ("\0" . $_[0]) ) }
 sub decode_u32 { unpack('N', $_[0]) }
 
-sub _id {
+sub getId {
 	my ($class, $url) = @_;
 
 	$url .= '&';
@@ -450,7 +450,7 @@ sub getNextTrack {
 
 	my $masterUrl = $song->track()->url;
 	my $client    = $song->master();
-	my $id = $class->_id($masterUrl);
+	my $id = $class->getId($masterUrl);
 	my $url = "http://www.youtube.com/watch?v=$id";
 
 	$log->info("next track id: $id url: $url master: $masterUrl");
@@ -640,7 +640,7 @@ sub getMetadataFor {
 
 	$log->debug("getmetadata: $url");
 	
-	my $id = $class->_id($url) || return {};
+	my $id = $class->getId($url) || return {};
 	my $cache = Slim::Utils::Cache->new;
 
 	if (my $meta = $cache->get("yt:meta-$id")) {
@@ -674,7 +674,7 @@ sub getMetadataFor {
 	for my $track ( @{ Slim::Player::Playlist::playList($client) } ) {
 		my $trackURL = blessed($track) ? $track->url : $track;
 		if ( $trackURL =~ m{youtube:/*(.+)} ) {
-			my $id = $class->_id($trackURL);
+			my $id = $class->getId($trackURL);
 			if ( $id && !$cache->get("yt:meta-$id") ) {
 				push @need, $id;
 			}
@@ -694,7 +694,6 @@ sub getMetadataFor {
 	Plugins::YouTube::API->getVideoDetails( sub {
 		my $result = shift;
 		
-warn Data::Dump::dump($result);
 		my $details;
 		
 		foreach my $item (@{$result->{items}}) {


### PR DESCRIPTION
Hi Philippe,

here's my suggested refactor of all things Youtube API interaction:

- all calls to the backend are implemented in the new API class
- API calls are cached in LMS to speed up interaction 
- main navigation is broken out into smaller methods, mostly wrappers around the API calls
- youtube playlists and channels are handled like, well, playlists: playing them would result in multiple items being queued up in LMS
- don't request track/video details for every item separately, but grab as many in one go as possible (up to 50)

Have fun :-)