### PR TITLE
Handle YouTube URLs passed to “Tune In URL”

### DIFF
--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -54,7 +54,8 @@ my $prefs = preferences('plugin.youtube');
 my $cache = Slim::Utils::Cache->new;
 
 Slim::Player::ProtocolHandlers->registerHandler('youtube', __PACKAGE__);
-Slim::Player::ProtocolHandlers->registerURLHandler(PAGE_URL_REGEXP, __PACKAGE__);
+Slim::Player::ProtocolHandlers->registerURLHandler(PAGE_URL_REGEXP, __PACKAGE__)
+    if Slim::Player::ProtocolHandlers->can('registerURLHandler');
 
 sub flushCache { $cache->cleanup(); }
 

--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -54,7 +54,7 @@ my $prefs = preferences('plugin.youtube');
 my $cache = Slim::Utils::Cache->new;
 
 Slim::Player::ProtocolHandlers->registerHandler('youtube', __PACKAGE__);
-Slim::Player::ProtocolHandlers->registerHandler(PAGE_URL_REGEXP, __PACKAGE__);
+Slim::Player::ProtocolHandlers->registerURLHandler(PAGE_URL_REGEXP, __PACKAGE__);
 
 sub flushCache { $cache->cleanup(); }
 

--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -47,7 +47,7 @@ use Plugins::YouTube::M4a;
 
 use constant MIN_OUT	=> 8192;
 use constant DATA_CHUNK => 128*1024;	
-use constant PAGE_URL_REGEXP => qr{^https://(?:www|m)\.youtube\.com/(?:watch\?|playlist\?|channel/)}i;
+use constant PAGE_URL_REGEXP => qr{^https?://(?:(?:www|m)\.youtube\.com/(?:watch\?|playlist\?|channel/)|youtu\.be/)}i;
 
 my $log   = logger('plugin.youtube');
 my $prefs = preferences('plugin.youtube');
@@ -314,6 +314,7 @@ sub getId {
 	if ($url =~ /^(?:youtube:\/\/)?https?:\/\/(?:www|m)\.youtube\.com\/watch\?v=([^&]*)/ ||
 		$url =~ /^youtube:\/\/(?:www|m)\.youtube\.com\/v\/([^&]*)/ ||
 		$url =~ /^youtube:\/\/([^&]*)/ ||
+		$url =~ m{^https?://youtu\.be/([a-zA-Z0-9_\-]+)}i ||
 		$url =~ /([a-zA-Z0-9_\-]+)/ )
 		{
 
@@ -917,7 +918,11 @@ sub explodePlaylist {
 
 		my $handler;
 		my $search;
-		if ( $uri->path eq '/watch' ) {
+		if ( $uri->host eq 'youtu.be' ) {
+			$handler = \&Plugins::YouTube::Plugin::urlHandler;
+			$search = ($uri->path_segments)[1];
+		}
+		elsif ( $uri->path eq '/watch' ) {
 			$handler = \&Plugins::YouTube::Plugin::urlHandler;
 			$search = $uri->query_param('v');
 		}

--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -47,7 +47,7 @@ use Plugins::YouTube::M4a;
 
 use constant MIN_OUT	=> 8192;
 use constant DATA_CHUNK => 128*1024;	
-use constant PAGE_URL_REGEXP => qr{^https://www\.youtube\.com/(?:watch\?|playlist\?|channel/)}i;
+use constant PAGE_URL_REGEXP => qr{^https://(?:www|m)\.youtube\.com/(?:watch\?|playlist\?|channel/)}i;
 
 my $log   = logger('plugin.youtube');
 my $prefs = preferences('plugin.youtube');
@@ -311,8 +311,8 @@ sub getId {
 
 	# also youtube://http://www.youtube.com/watch?v=tU0_rKD8qjw
 		
-	if ($url =~ /^(?:youtube:\/\/)?https?:\/\/www\.youtube\.com\/watch\?v=([^&]*)/ || 
-		$url =~ /^youtube:\/\/www\.youtube\.com\/v\/([^&]*)/ ||
+	if ($url =~ /^(?:youtube:\/\/)?https?:\/\/(?:www|m)\.youtube\.com\/watch\?v=([^&]*)/ ||
+		$url =~ /^youtube:\/\/(?:www|m)\.youtube\.com\/v\/([^&]*)/ ||
 		$url =~ /^youtube:\/\/([^&]*)/ ||
 		$url =~ /([a-zA-Z0-9_\-]+)/ )
 		{


### PR DESCRIPTION
A number of plugins allow you to give them a webpage URL, and they’ll play the music associated with that webpage, e.g., the Band’s Campout plugin has a “Bandcamp URL” field, the YouTube plugin has a “YouTube URL or Video id” field, etc.  However, it would be more convenient if you could paste the URL into the “Tune In URL” field and have LMS work out for you which plugin to use.

This pull request provides that for YouTube videos, playlists, and channels.

Support for this in LMS landed on the public/8.0 branch today, but this change should safely do nothing on older versions.