### PR TITLE
Handle YouTube URLs passed to “Tune In URL”

### DIFF
--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -952,7 +952,7 @@ sub explodePlaylist {
 		);
 	}
 	else {
-		$cb->([]);
+		$cb->([$uri]);
 	}
 }
 


### PR DESCRIPTION
This follows on from reverted #23.

I've tested on a 8.0 nightly and a fresh installation of 7.9.2, and playing from YouTube in the traditional way is now working again for me.