### PR TITLE
Fix playlist stopping between tracks; add retry logic to getNextTrack

### DIFF
--- a/plugin/ProtocolHandler.pm
+++ b/plugin/ProtocolHandler.pm
@@ -73,6 +73,7 @@ my @audioId = (
 	{ id => 251, codec => 'ops', rate => 160_000 }, { id => 250, codec => 'ops', rate => 70_000 }, { id => 249, codec => 'ops', rate => 50_000 },
 	{ id => 171, codec => 'ogg', rate => 128_000 },
 	{ id => 141, codec => 'aac', rate => 256_000 }, { id => 140, codec => 'aac', rate => 128_000 }, { id => 139, codec => 'aac', rate => 48_000 },
+    { id => 22,  codec => 'aac', rate => 128_000 }, { id => 18,  codec => 'aac', rate => 96_000 },
 );
 
 my @videoId = (
@@ -602,12 +603,33 @@ sub getId {
 	return undef;
 }
 
-sub getNextTrack {
-	my ($class, $song, $successCb, $errorCb,) = @_;
+sub getNextTrack {	
+	my ($class, $song, $successCb, $errorCb, $_retries) = @_;
+
+	my $MAX_RETRIES = 3;
+	my $RETRY_DELAY = 2;  # seconds between retries
+
+	$_retries //= $MAX_RETRIES;
+
+	my $retryOrFail = sub {
+		my $reason = shift;
+		if ($_retries > 0) {
+			$_retries--;
+			$log->warn("getNextTrack failed ($reason), retrying in ${RETRY_DELAY}s ($_retries retries left)");
+			Slim::Utils::Timers::setTimer(
+				undef,
+				Time::HiRes::time() + $RETRY_DELAY,
+				sub { $class->getNextTrack($song, $successCb, $errorCb, $_retries) }
+			);
+		} else {
+			$log->error("getNextTrack failed ($reason), no retries left");
+			$errorCb->($reason);
+		}
+	};
 
 	my $yt_dlp = Plugins::YouTube::Utils::yt_dlp_bin($prefs->get('yt_dlp'));
 	$log->info("Using yt_dlp $yt_dlp");
-	return $_[3]->("cannot find yt-dlp") unless $yt_dlp;
+	return $retryOrFail->("cannot find yt-dlp") unless $yt_dlp;
 
 	my $masterUrl = $song->track()->url;
 
@@ -650,12 +672,15 @@ sub getNextTrack {
 			main::INFOLOG && $log->is_info && $log->info("yt-dlp finished with $exitcode in ", time() - $now, " seconds");
 			$tracks = eval { decode_json($tracks) };
 
-			$log->error("yt-dlp failed") && $errorCb->($@) && return if $@ || !$tracks;
+			return $retryOrFail->($@ || "yt-dlp returned no tracks") if $@ || !$tracks;
 
 			# duration is at the top level
 			$song->track->secs( $tracks->{'duration'} );
 
-			_getNextTrack($class, $song, $successCb, $errorCb, _selectTracks($tracks->{formats}));
+			my $selected = _selectTracks($tracks->{formats});
+			return $retryOrFail->("no matching track") unless @$selected;
+
+			_getNextTrack($class, $song, $successCb, sub { $retryOrFail->(shift) }, $selected);
 		};
 
 		Slim::Utils::Timers::setTimer($pid, Time::HiRes::time() + 0.25, $lambda);
@@ -672,12 +697,15 @@ sub getNextTrack {
 			main::INFOLOG && $log->is_info && $log->info("yt-dlp finished in ", time() - $now, " seconds");
 			$tracks = eval { decode_json($tracks) };
 
-			$log->error("yt-dlp failed $err") && $errorCb->($@) && return if $@ || !$tracks;
+			return $retryOrFail->($@ || "yt-dlp returned no tracks") if $@ || !$tracks;
 
 			# duration is at the top level
 			$song->track->secs( $tracks->{'duration'} );
 
-			_getNextTrack($class, $song, $successCb, $errorCb, _selectTracks($tracks->{formats}));
+			my $selected = _selectTracks($tracks->{formats});
+			return $retryOrFail->("no matching track") unless @$selected;
+
+			_getNextTrack($class, $song, $successCb, sub { $retryOrFail->(shift) }, $selected);
 		});
 	}
 }
@@ -707,16 +735,19 @@ sub _selectTracks{
 	foreach my $item (@audioId) {
 		next unless $codecs =~ /$item->{codec}/;
 		my ($track) = grep { $_->{format_id} =~ /^$item->{id}/ } @$tracks;
-		push @selected, $track if $track;
-		$track->{_id} = $item;
+        if ($track) {
+            $track->{_id} = $item;
+            push @selected, $track;
+        }
 	}
-
 	# add video if allowed
 	if ($prefs->get('use_video')) {
 		foreach my $item (@videoId) {
 			my ($track) = grep { $_->{format_id} =~ /^$item->{id}/ } @$tracks;
-			push @selected, $track if $track;
-			$track->{_id} = $item;
+			if ($track) {
+				$track->{_id} = $item;
+				push @selected, $track;
+			}
 		}
 	}
 


### PR DESCRIPTION
**Fix playlist stopping between tracks; add retry logic to `getNextTrack`**

This PR fixes a bug that caused playlist playback to stop between tracks instead of advancing automatically, and adds automatic retry logic to make the player resilient against the transient yt-dlp failures that triggered it.

**Bug**

When yt-dlp resolves a track's stream URL, YouTube occasionally returns only format 18 — a legacy muxed 360p mp4 — instead of the expected audio-only streams (opus/ogg/aac). Since format 18 is not present in the `@audioId` or `@videoId` lookup tables, `_selectTracks` returns an empty list, `_getNextTrack` finds no matching track and calls `errorCb`, causing LMS to stop playback entirely. Because the track is not removed from the playlist, pressing play manually succeeds — typically because yt-dlp returns proper audio streams on the second attempt.

A secondary bug existed in `_selectTracks`: in the audio loop, `$track->{_id} = $item` was executed after the `push` and unconditionally, meaning it ran even when no matching track was found (leaving `$track` undef), and any pushed track had `_id` unset at the point it was pushed.

**Changes**

`getNextTrack` now accepts an optional `$_retries` parameter, defaulting to 3. On any failure — yt-dlp parse error, no matching tracks, or stream initialisation failure from `_getNextTrack` — a `$retryOrFail` closure either schedules a fresh attempt via `Slim::Utils::Timers::setTimer` after a 2-second delay, or calls the real `errorCb` once all retries are exhausted. The 2-second delay avoids immediately hammering YouTube's CDN and gives the event loop room to breathe. The `$retryOrFail` closure is passed down as the error callback to `_getNextTrack` as well, so failures at the stream initialisation level are retried on the same terms.

In `_selectTracks`, both the audio and video loops are corrected to assign `$track->{_id}` before pushing, and only when a matching track was actually found.